### PR TITLE
Feat: Background Color

### DIFF
--- a/floax.tmux
+++ b/floax.tmux
@@ -14,5 +14,6 @@ tmux setenv -g FLOAX_BORDER_COLOR "$(tmux_option_or_fallback '@floax-border-colo
 tmux setenv -g FLOAX_TEXT_COLOR "$(tmux_option_or_fallback '@floax-text-color' 'blue')" 
 tmux setenv -g FLOAX_TITLE "$(tmux_option_or_fallback '@floax-title' "${DEFAULT_TITLE}")"
 tmux setenv -g FLOAX_CHANGE_PATH "$(tmux_option_or_fallback '@floax-change-path' 'true')" 
+tmux setenv -g FLOAX_WINDOW_BG "$(tmux_option_or_fallback '@floax-window-bg' '')"
 
 eval "$(tmux showenv -s)"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,6 +21,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLOAX_CHANGE_PATH=$(envvar_value FLOAX_CHANGE_PATH)
 FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
 DEFAULT_TITLE='FloaX: C-a-s 󰘕   C-a-b 󰁌   C-a-f 󰊓   C-a-r 󰑓   C-a-e 󱂬   C-a-d '
+FLOAX_WINDOW_BG=$(envvar_value FLOAX_WINDOW_BG)
 
 set_bindings() {
     tmux bind -n C-M-s run "$CURRENT_DIR/zoom-options.sh in"
@@ -54,6 +55,9 @@ tmux_popup() {
     scratch_path=$(tmux display -t scratch -p '#{pane_current_path}')
     if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
         tmux send-keys -R -t scratch "cd $current_dir" C-m
+    fi
+    if [ FLOAX_WINDOW_BG ]; then
+      tmux set-option -s -t scratch window-style "bg=$FLOAX_WINDOW_BG"
     fi
     if ! pop; then
         tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 


### PR DESCRIPTION
I use a transparent background which doesn't look very good with tmux's popup windows. Luckily with tmux you can set the background of the popup window with `tmux -s -t scratch window-style bg=1e1e2e`.

I've tested the code and it "works" however I cant get the global variables to work.

Without BG:
![image](https://github.com/user-attachments/assets/1ce71342-800b-469f-b475-858fee3b38fc)

With BG set:
![image](https://github.com/user-attachments/assets/d258c7d7-3064-4d03-80f3-45d290e5153c)
