### PR TITLE
fix: infinite loop issue on unsupported tmux versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This message will be removed as soon as it's ready to be used in production.
 
 ## Install 💻
 
+Tmux version 3.3 or newer is required to use this plugin.
+
 Add this to your `.tmux.conf` and run `Ctrl-I` for TPM to install the plugin.
 ```conf
 set -g @plugin 'omerxx/tmux-floax'

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -70,7 +70,7 @@ tmux_popup() {
     current_dir=$(tmux display -p '#{pane_current_path}')
     scratch_path=$(tmux display -t scratch -p '#{pane_current_path}')
     if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
-        tmux send-keys -R -t scratch "cd $current_dir" C-m
+        tmux send-keys -R -t "$FLOAX_SESSION_NAME" " cd $current_dir" C-m
     fi
 
     if is_tmux_version_supported; then

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -46,7 +46,17 @@ unset_bindings() {
 
 tmux_popup() {
     FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
+    if [ "$FLOAX_WIDTH" = "" ]; then
+        FLOAX_WIDTH="$(tmux_option_or_fallback '@floax-width' '80%')" 
+        tmux setenv -g FLOAX_WIDTH "$FLOAX_WIDTH" 
+    fi
+
     FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
+    if [ "$FLOAX_HEIGHT" = "" ]; then
+        FLOAX_HEIGHT="$(tmux_option_or_fallback '@floax-height' '80%')" 
+        tmux setenv -g FLOAX_HEIGHT "$FLOAX_HEIGHT" 
+    fi
+
     FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
     if [ -z "$FLOAX_TITLE" ]; then
         FLOAX_TITLE="$DEFAULT_TITLE"
@@ -64,12 +74,8 @@ tmux_popup() {
     if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
         tmux send-keys -R -t "$FLOAX_SESSION_NAME" " cd $current_dir" C-m
     fi
-    if ! pop; then
-        tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 
-        tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')" 
-        tmux_popup
-    fi
 
+    pop
 }
 
 pop() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -78,14 +78,41 @@ tmux_popup() {
     pop
 }
 
+tmux_version() {
+  tmux -V | cut -d ' ' -f 2
+}
+
+# Checks whether tmux version is >= 3.3
+is_tmux_version_supported() {
+    local version
+    IFS='.' read -r -a version < <(tmux_version)
+
+    if [ "${version[0]}" -gt 3 ]; then
+        return 0
+    fi
+
+    # Minor version can be a number or alphanumeric, e.g. 3.3 vs 3.3a
+    if [ "${version[0]}" -eq 3 ] && [ "${version[1]//[!0-9]}" -ge 3 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
 pop() {
-    tmux popup \
-        -S fg="$FLOAX_BORDER_COLOR" \
-        -s fg="$FLOAX_TEXT_COLOR" \
-        -T "$FLOAX_TITLE" \
-        -w "$FLOAX_WIDTH" \
-        -h "$FLOAX_HEIGHT" \
-        -b rounded \
-        -E \
-        "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
+    if is_tmux_version_supported; then
+        tmux popup \
+            -S fg="$FLOAX_BORDER_COLOR" \
+            -s fg="$FLOAX_TEXT_COLOR" \
+            -T "$FLOAX_TITLE" \
+            -w "$FLOAX_WIDTH" \
+            -h "$FLOAX_HEIGHT" \
+            -b rounded \
+            -E \
+            "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
+    else
+        tmux display-message \
+            -d 2000 \
+            "FloaX requires tmux version 3.3 or newer"
+    fi
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -44,40 +44,6 @@ unset_bindings() {
     tmux unbind -n C-M-u 
 }
 
-tmux_popup() {
-    FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
-    if [ "$FLOAX_WIDTH" = "" ]; then
-        FLOAX_WIDTH="$(tmux_option_or_fallback '@floax-width' '80%')" 
-        tmux setenv -g FLOAX_WIDTH "$FLOAX_WIDTH" 
-    fi
-
-    FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
-    if [ "$FLOAX_HEIGHT" = "" ]; then
-        FLOAX_HEIGHT="$(tmux_option_or_fallback '@floax-height' '80%')" 
-        tmux setenv -g FLOAX_HEIGHT "$FLOAX_HEIGHT" 
-    fi
-
-    FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
-    if [ -z "$FLOAX_TITLE" ]; then
-        FLOAX_TITLE="$DEFAULT_TITLE"
-    fi
-
-    FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
-    if [ -z "$FLOAX_SESSION_NAME" ]; then
-        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
-    fi
-
-
-    # TODO: make this optional:
-    current_dir=$(tmux display -p '#{pane_current_path}')
-    scratch_path=$(tmux display -t scratch -p '#{pane_current_path}')
-    if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
-        tmux send-keys -R -t "$FLOAX_SESSION_NAME" " cd $current_dir" C-m
-    fi
-
-    pop
-}
-
 tmux_version() {
   tmux -V | cut -d ' ' -f 2
 }
@@ -99,20 +65,48 @@ is_tmux_version_supported() {
     return 1
 }
 
-pop() {
+tmux_popup() {
+    # TODO: make this optional:
+    current_dir=$(tmux display -p '#{pane_current_path}')
+    scratch_path=$(tmux display -t scratch -p '#{pane_current_path}')
+    if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
+        tmux send-keys -R -t scratch "cd $current_dir" C-m
+    fi
+
     if is_tmux_version_supported; then
-        tmux popup \
-            -S fg="$FLOAX_BORDER_COLOR" \
-            -s fg="$FLOAX_TEXT_COLOR" \
-            -T "$FLOAX_TITLE" \
-            -w "$FLOAX_WIDTH" \
-            -h "$FLOAX_HEIGHT" \
-            -b rounded \
-            -E \
-            "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
+        if ! pop; then
+            tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 
+            tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')"
+            pop
+        fi
     else
         tmux display-message \
             -d 2000 \
             "FloaX requires tmux version 3.3 or newer"
     fi
+}
+
+pop() {
+    FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
+    FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
+
+    FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
+    if [ -z "$FLOAX_TITLE" ]; then
+        FLOAX_TITLE="$DEFAULT_TITLE"
+    fi
+
+    FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
+    if [ -z "$FLOAX_SESSION_NAME" ]; then
+        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
+    fi
+
+    tmux popup \
+        -S fg="$FLOAX_BORDER_COLOR" \
+        -s fg="$FLOAX_TEXT_COLOR" \
+        -T "$FLOAX_TITLE" \
+        -w "$FLOAX_WIDTH" \
+        -h "$FLOAX_HEIGHT" \
+        -b rounded \
+        -E \
+        "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
 }


### PR DESCRIPTION
This will fix the issue described in #8 by
* refactoring code to remove infinite loop
* displaying error message on unsupported tmux versions

Tmux 3.3 should have all the required features for this plugin to work correctly. It is also possible to support tmux 3.2 by removing popup styling and title:

```sh
tmux popup \
    -w "$FLOAX_WIDTH" \
    -h "$FLOAX_HEIGHT" \
    -E \
    "tmux attach-session -t scratch"
```