### PR TITLE
fix: title reset to default after second trigger

### DIFF
--- a/scripts/floax.sh
+++ b/scripts/floax.sh
@@ -6,8 +6,13 @@ source "$CURRENT_DIR/utils.sh"
 tmux setenv -g ORIGIN_SESSION "$(tmux display -p '#{session_name}')"
 if [ "$(tmux display-message -p '#{session_name}')" = "scratch" ]; then
     unset_bindings
-    change_popup_title "$DEFAULT_TITLE"
-    tmux setenv -g FLOAX_TITLE "$DEFAULT_TITLE"
+
+    if [ -z "$FLOAX_TITLE" ]; then
+        FLOAX_TITLE="$DEFAULT_TITLE"
+    fi
+
+    change_popup_title "$FLOAX_TITLE"
+    tmux setenv -g FLOAX_TITLE "$FLOAX_TITLE"
     tmux detach-client
 else
     # Check if the session 'scratch' exists


### PR DESCRIPTION
`FLOAX_TITLE` env variable reverts back to `DEFAULT_TITLE` after the second trigger of floax.

TMUX configuration file has a value set for floax title (ex `set -g @floax-title "This is a title"`)
On first trigger of floax, the custom title is displayed. After that, any subsequent trigger will display the default title again (`FloaX: C-a-s ...`)

This PR fixes this issue by setting the `FLOAX_TITLE` env variable to the custom title (if one was provided).

---

The issue:

https://github.com/user-attachments/assets/be257b76-53dc-4468-8307-22c37f651b73

