### PR TITLE
feat: make border style configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ set -g @floax-height '80%'
 # black, red, green, yellow, blue, magenta, cyan, white
 set -g @floax-border-color 'magenta'
 
+# The border style can be changed, these are the styles supported by Tmux:
+# none, single, double, rounded
+set -g @floax-border-style 'rounded'
+
 # The text color can also be changed, by default it's blue 
 # to distinguish from the main window
 # Optional colors are as shown above in @floax-border-color

--- a/floax.tmux
+++ b/floax.tmux
@@ -6,13 +6,15 @@ source "$CURRENT_DIR/scripts/utils.sh"
 tmux bind-key $(tmux_option_or_fallback "@floax-bind" "p") run-shell "$CURRENT_DIR/floax.sh"
 tmux bind-key "$(tmux_option_or_fallback "@floax-bind-menu" "P")" run-shell "$CURRENT_DIR/menu.sh"
 
-tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 
-tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')" 
+tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')"
+tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')"
 
 # Options: black, red, green, yellow, blue, magenta, cyan, white
-tmux setenv -g FLOAX_BORDER_COLOR "$(tmux_option_or_fallback '@floax-border-color' 'magenta')" 
-tmux setenv -g FLOAX_TEXT_COLOR "$(tmux_option_or_fallback '@floax-text-color' 'blue')" 
+tmux setenv -g FLOAX_BORDER_COLOR "$(tmux_option_or_fallback '@floax-border-color' 'magenta')"
+# Options: none, single, double, rounded
+tmux setenv -g FLOAX_BORDER_STYLE "$(tmux_option_or_fallback '@floax-border-style' 'rounded')"
+tmux setenv -g FLOAX_TEXT_COLOR "$(tmux_option_or_fallback '@floax-text-color' 'blue')"
 tmux setenv -g FLOAX_TITLE "$(tmux_option_or_fallback '@floax-title' "${DEFAULT_TITLE}")"
-tmux setenv -g FLOAX_CHANGE_PATH "$(tmux_option_or_fallback '@floax-change-path' 'true')" 
+tmux setenv -g FLOAX_CHANGE_PATH "$(tmux_option_or_fallback '@floax-change-path' 'true')"
 
 eval "$(tmux showenv -s)"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -16,6 +16,7 @@ tmux_option_or_fallback() {
 FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
 FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
 FLOAX_BORDER_COLOR=$(envvar_value FLOAX_BORDER_COLOR)
+FLOAX_BORDER_STYLE=$(envvar_value FLOAX_BORDER_STYLE)
 FLOAX_TEXT_COLOR=$(envvar_value FLOAX_TEXT_COLOR)
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLOAX_CHANGE_PATH=$(envvar_value FLOAX_CHANGE_PATH)
@@ -70,7 +71,7 @@ pop() {
         -T "$FLOAX_TITLE" \
         -w "$FLOAX_WIDTH" \
         -h "$FLOAX_HEIGHT" \
-        -b rounded \
+        -b "$FLOAX_BORDER_STYLE" \
         -E \
         "tmux attach-session -t scratch" 
 }


### PR DESCRIPTION
Hi, it'll be great that we can configure the border style

<img width="1393" alt="SCR-20240724-kaez" src="https://github.com/user-attachments/assets/01c25c5c-8449-4ee8-9cba-aa80814fd28d">
