### PR TITLE
Add: Dynamic floating pane session name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ set -g @floax-text-color 'blue'
 # You can disable this by setting it to false
 # You could also "cd -" when the pane is toggled to go back
 set -g @floax-change-path 'true'
+
+# The default session name of the floating pane is 'scratch'
+# You can modify the session name with this option:
+set -g @floax-session-name 'some-other-session-name'
 ```
 
 ## Known issues 🐞

--- a/floax.tmux
+++ b/floax.tmux
@@ -14,5 +14,6 @@ tmux setenv -g FLOAX_BORDER_COLOR "$(tmux_option_or_fallback '@floax-border-colo
 tmux setenv -g FLOAX_TEXT_COLOR "$(tmux_option_or_fallback '@floax-text-color' 'blue')" 
 tmux setenv -g FLOAX_TITLE "$(tmux_option_or_fallback '@floax-title' "${DEFAULT_TITLE}")"
 tmux setenv -g FLOAX_CHANGE_PATH "$(tmux_option_or_fallback '@floax-change-path' 'true')" 
+tmux setenv -g FLOAX_SESSION_NAME "$(tmux_option_or_fallback '@floax-session-name' "${DEFAULT_SESSION_NAME}")"
 
 eval "$(tmux showenv -s)"

--- a/scripts/embed.sh
+++ b/scripts/embed.sh
@@ -5,7 +5,7 @@ source "$CURRENT_DIR/utils.sh"
 
 embed() {
     unset_bindings
-    number_of_windows=$(tmux list-windows -t scratch | wc -l)
+    number_of_windows=$(tmux list-windows -t "$FLOAX_SESSION_NAME" | wc -l)
     if [ "$number_of_windows" -eq 1 ]; then
         # there's only one window, need to create an alternative
         # before moving the current one to another session
@@ -17,7 +17,7 @@ embed() {
 }
 
 pop() {
-    tmux movew -t scratch
+    tmux movew -t "$FLOAX_SESSION_NAME"
     tmux_popup
 }
 

--- a/scripts/floax.sh
+++ b/scripts/floax.sh
@@ -4,11 +4,15 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/utils.sh"
 
 tmux setenv -g ORIGIN_SESSION "$(tmux display -p '#{session_name}')"
-if [ "$(tmux display-message -p '#{session_name}')" = "scratch" ]; then
+if [ "$(tmux display-message -p '#{session_name}')" = "$FLOAX_SESSION_NAME" ]; then
     unset_bindings
 
     if [ -z "$FLOAX_TITLE" ]; then
         FLOAX_TITLE="$DEFAULT_TITLE"
+    fi
+
+    if [ -z "$FLOAX_SESSION_NAME" ]; then
+        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
     fi
 
     change_popup_title "$FLOAX_TITLE"
@@ -16,13 +20,13 @@ if [ "$(tmux display-message -p '#{session_name}')" = "scratch" ]; then
     tmux detach-client
 else
     # Check if the session 'scratch' exists
-    if tmux has-session -t scratch 2>/dev/null; then
+    if tmux has-session -t "$FLOAX_SESSION_NAME" 2>/dev/null; then
         set_bindings
         tmux_popup
     else
         # Create a new session named 'scratch' and attach to it
-        tmux new-session -d -c "$(tmux display-message -p '#{pane_current_path}')" -s scratch
-        tmux set-option -t scratch status off
+        tmux new-session -d -c "$(tmux display-message -p '#{pane_current_path}')" -s "$FLOAX_SESSION_NAME"
+        tmux set-option -t "$FLOAX_SESSION_NAME" status off
         tmux_popup
     fi
 fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -4,7 +4,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Function to check if the current session name matches "scratch"
 check_current_session() {
     current_session=$(tmux display-message -p '#{session_name}')
-    if [ "$current_session" != "scratch" ]; then
+    if [ "$current_session" != "$FLOAX_SESSION_NAME" ]; then
         tmux menu \
             "pop current window" p "run \"$CURRENT_DIR/embed.sh pop\"" 
         exit 0

--- a/scripts/move.sh
+++ b/scripts/move.sh
@@ -25,5 +25,5 @@ esac;
 # pane_bottom=$(tmux display-message -p '#{pane_bottom}')
 # pane_right=$(tmux display-message -p '#{pane_right}')
 tmux detach-client
-tmux popup -E "$motion" "tmux attach-session -t scratch"
+tmux popup -E "$motion" "tmux attach-session -t \"$FLOAX_SESSION_NAME\""
 # tmux display-message "$pane_top $pane_left $motion"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,6 +21,8 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLOAX_CHANGE_PATH=$(envvar_value FLOAX_CHANGE_PATH)
 FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
 DEFAULT_TITLE='FloaX: C-M-s 󰘕   C-M-b 󰁌   C-M-f 󰊓   C-M-r 󰑓   C-M-e 󱂬   C-M-d '
+FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
+DEFAULT_SESSION_NAME='scratch'
 
 set_bindings() {
     tmux bind -n C-M-s run "$CURRENT_DIR/zoom-options.sh in"
@@ -49,11 +51,18 @@ tmux_popup() {
     if [ -z "$FLOAX_TITLE" ]; then
         FLOAX_TITLE="$DEFAULT_TITLE"
     fi
+
+    FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
+    if [ -z "$FLOAX_SESSION_NAME" ]; then
+        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
+    fi
+
+
     # TODO: make this optional:
     current_dir=$(tmux display -p '#{pane_current_path}')
     scratch_path=$(tmux display -t scratch -p '#{pane_current_path}')
     if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
-        tmux send-keys -R -t scratch "cd $current_dir" C-m
+        tmux send-keys -R -t "$FLOAX_SESSION_NAME" " cd $current_dir" C-m
     fi
     if ! pop; then
         tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 
@@ -72,5 +81,5 @@ pop() {
         -h "$FLOAX_HEIGHT" \
         -b rounded \
         -E \
-        "tmux attach-session -t scratch" 
+        "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
 }


### PR DESCRIPTION
New configuration option to change the default session name (default: `scratch`)

User can specify the following option in `tmux.conf`
```bash
set -g @floax-session-name 'some-other-session-name'
```
![Screenshot 2024-08-01 at 13 32 04](https://github.com/user-attachments/assets/3a839585-c249-44c0-82f7-160b5e69275a)
