### PR TITLE
fix: envvar_value logic to handle '=' in tmux variable values

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 envvar_value() {
-    tmux showenv -g "$1" | cut -d '=' -f 2
+    tmux showenv -g "$1" | cut -d '=' -f 2-
 }
 
 tmux_option_or_fallback() {


### PR DESCRIPTION
I wanted to embed styles in `FLOAX_TITLE`, but the current `envvar_value` function couldn't correctly extract the value when it contains an equal sign `=`. This fix addresses that issue.
```bash
﻿tmux setenv -g FLOAX_TITLE "[#align=centre,fg=red]My Test Title"
﻿tmux showenv -g "FLOAX_TITLE" | cut -d '=' -f 2 # [#align
tmux showenv -g "FLOAX_TITLE" | cut -d '=' -f 2- # [#align=centre,fg=red]My Test Title
```