### PR TITLE
Include @floax-title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ set -g @floax-change-path 'true'
 # The default session name of the floating pane is 'scratch'
 # You can modify the session name with this option:
 set -g @floax-session-name 'some-other-session-name'
+
+# Change the title of the floating window
+set -g @floax-title 'floax'
 ```
 
 ## Known issues 🐞


### PR DESCRIPTION
Includes undocumented variable `@floax-title` in the documentation