### PR TITLE
feat: improve tmux version extraction

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -45,7 +45,11 @@ unset_bindings() {
 }
 
 tmux_version() {
-  tmux -V | cut -d ' ' -f 2
+    # extract the version number only
+    # works with input like:
+        # tmux next-x.x
+        # tmux x.x
+    tmux -V | awk '{print $NF}' | sed 's/^[^0-9]*//'
 }
 
 # Checks whether tmux version is >= 3.3


### PR DESCRIPTION
Make version extraction more robust to handle outputs like "tmux next-3.5" by stripping non-numeric prefixes. Ensures compatibility with varied tmux -V output formats.