### PR TITLE
Fix: Kill tmux session on popup close to prevent crashes (#20)

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -109,5 +109,6 @@ pop() {
         -h "$FLOAX_HEIGHT" \
         -b rounded \
         -E \
-        "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
+        "tmux attach-session -t \"$FLOAX_SESSION_NAME\""
+    tmux kill-session -t "$FLOAX_SESSION_NAME"
 }


### PR DESCRIPTION
Adds `tmux kill-session -t "$FLOAX_SESSION_NAME"` to the `pop` function in `scripts/utils.sh`.

This should prevent tmux from crashing when the floax popup is closed by explicitly terminating the associated tmux session.