### PR TITLE
fix: set window title correctly when unlocking bindings

### DIFF
--- a/scripts/zoom-options.sh
+++ b/scripts/zoom-options.sh
@@ -36,7 +36,7 @@ reset_size() {
 
 unlock_bindings() {
     set_bindings
-    change_popup_title "$DEFAULT_TITLE"
+    change_popup_title "$FLOAX_TITLE"
 }
 
 lock_bindings() {


### PR DESCRIPTION
- Use `$FLOAX_TITLE` instead of `$DEFAULT_TITLE` when unlocking bindings in a FloaX window.