### PR TITLE
fix: always set keybindings whether a floax session already exists or…

### DIFF
--- a/scripts/floax.sh
+++ b/scripts/floax.sh
@@ -19,9 +19,10 @@ if [ "$(tmux display-message -p '#{session_name}')" = "$FLOAX_SESSION_NAME" ]; t
     tmux setenv -g FLOAX_TITLE "$FLOAX_TITLE"
     tmux detach-client
 else
+    set_bindings
+
     # Check if the session 'scratch' exists
     if tmux has-session -t "$FLOAX_SESSION_NAME" 2>/dev/null; then
-        set_bindings
         tmux_popup
     else
         # Create a new session named 'scratch' and attach to it


### PR DESCRIPTION
I had the same bug as described here #56 .
After looking into it I saw that the keybindings are not set when a new session is created, only if the session already exists.

## Summary

• Add set_bindings call when creating a new floax session to ensure keybindings are consistently available regardless of whether the session existed beforehand.