### PR TITLE
Use user's terminal text color instead of hardcoded blue default

### DIFF
--- a/floax.tmux
+++ b/floax.tmux
@@ -11,7 +11,7 @@ tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')"
 
 # Options: black, red, green, yellow, blue, magenta, cyan, white
 tmux setenv -g FLOAX_BORDER_COLOR "$(tmux_option_or_fallback '@floax-border-color' 'magenta')" 
-tmux setenv -g FLOAX_TEXT_COLOR "$(tmux_option_or_fallback '@floax-text-color' 'blue')" 
+tmux setenv -g FLOAX_TEXT_COLOR "$(tmux_option_or_fallback '@floax-text-color' "${DEFAULT_TEXT_COLOR}")" 
 tmux setenv -g FLOAX_TITLE "$(tmux_option_or_fallback '@floax-title' "${DEFAULT_TITLE}")"
 tmux setenv -g FLOAX_CHANGE_PATH "$(tmux_option_or_fallback '@floax-change-path' 'true')" 
 tmux setenv -g FLOAX_SESSION_NAME "$(tmux_option_or_fallback '@floax-session-name' "${DEFAULT_SESSION_NAME}")"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -17,6 +17,11 @@ FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
 FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
 FLOAX_BORDER_COLOR=$(envvar_value FLOAX_BORDER_COLOR)
 FLOAX_TEXT_COLOR=$(envvar_value FLOAX_TEXT_COLOR)
+DEFAULT_TEXT_COLOR=$(
+    tmux show-options -gv message-style | sed -n 's/.*fg=\([^,]*\).*/\1/p' ||
+        tmux show-options -gv status-style | sed -n 's/.*fg=\([^,]*\).*/\1/p' ||
+        echo "default"
+)
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FLOAX_CHANGE_PATH=$(envvar_value FLOAX_CHANGE_PATH)
 FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
@@ -98,6 +103,11 @@ pop() {
     FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
     if [ -z "$FLOAX_SESSION_NAME" ]; then
         FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
+    fi
+
+    FLOAX_TEXT_COLOR=$(envvar_value FLOAX_TEXT_COLOR)
+    if [ -z "$FLOAX_TEXT_COLOR" ]; then
+        FLOAX_TEXT_COLOR="$DEFAULT_TEXT_COLOR"
     fi
 
     tmux set-option -t "$FLOAX_SESSION_NAME" detach-on-destroy on


### PR DESCRIPTION
Extract foreground color from tmux message-style or status-style as default, falling back to 'default' keyword if neither is configured. This uses user's tmux color scheme rather than forcing blue text color.