### PR TITLE
fix: remove terminal reset and add idle check before cd

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -69,11 +69,16 @@ tmux_popup() {
     if [ -z "$FLOAX_SESSION_NAME" ]; then
         FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
     fi
-    # TODO: make this optional:
-    current_dir=$(tmux display -p '#{pane_current_path}')
-    scratch_path=$(tmux display -t "$FLOAX_SESSION_NAME" -p '#{pane_current_path}')
-    if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
-        tmux send-keys -R -t "$FLOAX_SESSION_NAME" " cd \"$current_dir\"" C-m
+    if [ "$FLOAX_CHANGE_PATH" = "true" ]; then
+        current_dir=$(tmux display -p '#{pane_current_path}')
+        scratch_path=$(tmux display -t "$FLOAX_SESSION_NAME" -p '#{pane_current_path}')
+        if [ "$scratch_path" != "$current_dir" ]; then
+            # Check if the pane is idle (at a shell prompt) before sending cd
+            pane_cmd=$(tmux display -t "$FLOAX_SESSION_NAME" -p '#{pane_current_command}')
+            if [ "$pane_cmd" = "bash" ] || [ "$pane_cmd" = "zsh" ] || [ "$pane_cmd" = "fish" ] || [ "$pane_cmd" = "sh" ]; then
+                tmux send-keys -R -t "$FLOAX_SESSION_NAME" " cd \"$current_dir\"" C-m
+            fi
+        fi
     fi
 
     if is_tmux_version_supported; then


### PR DESCRIPTION
# Context

When the floating terminal is up, sometimes it shows jaggy output (on separate lines unformatted like a normal terminal) and if an app is running (example Lazygit) that requires an input confirmation from the user, it lags and I have to kill it manually.

The problem is because of resetting the terminal and immediately sending keystrokes to navigate to the current active directory. 

# Fix Summary

Fix was simply to wait until the pane is ideal and send the shell prompt to navigate into directory. 

