### PR TITLE
feat: add per-session popup windows via @floax-per-session option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ set -g @floax-change-path 'true'
 # You can modify the session name with this option:
 set -g @floax-session-name 'some-other-session-name'
 
+# By default, all tmux sessions share a single floating pane session.
+# When per-session mode is enabled, each tmux session gets its own
+# floating pane (e.g. 'scratch_myproject', 'scratch_dev').
+# This is useful when working with multiple sessions simultaneously.
+set -g @floax-per-session 'true'
+
 # Change the title of the floating window
 set -g @floax-title 'floax'
 ```

--- a/floax.tmux
+++ b/floax.tmux
@@ -15,5 +15,6 @@ tmux setenv -g FLOAX_TEXT_COLOR "$(tmux_option_or_fallback '@floax-text-color' '
 tmux setenv -g FLOAX_TITLE "$(tmux_option_or_fallback '@floax-title' "${DEFAULT_TITLE}")"
 tmux setenv -g FLOAX_CHANGE_PATH "$(tmux_option_or_fallback '@floax-change-path' 'true')" 
 tmux setenv -g FLOAX_SESSION_NAME "$(tmux_option_or_fallback '@floax-session-name' "${DEFAULT_SESSION_NAME}")"
+tmux setenv -g FLOAX_PER_SESSION "$(tmux_option_or_fallback '@floax-per-session' 'false')"
 
 eval "$(tmux showenv -s)"

--- a/scripts/embed.sh
+++ b/scripts/embed.sh
@@ -5,13 +5,13 @@ source "$CURRENT_DIR/utils.sh"
 
 # Must set these BEFORE using them in functions
 ORIGIN_SESSION="$(envvar_value ORIGIN_SESSION)"
-if [ -z "$FLOAX_SESSION_NAME" ]; then
-    FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
-fi
+
+# Derive the effective per-session floax session name
+effective_session="$(floax_effective_session "$ORIGIN_SESSION")"
 
 embed() {
     unset_bindings
-    number_of_windows=$(tmux list-windows -t "$FLOAX_SESSION_NAME" | wc -l)
+    number_of_windows=$(tmux list-windows -t "$effective_session" | wc -l)
     if [ "$number_of_windows" -eq 1 ]; then
         # there's only one window, need to create an alternative
         # before moving the current one to another session
@@ -24,12 +24,12 @@ embed() {
 
 pop() {
     # Ensure scratch session exists before trying to move window to it
-    if ! tmux has-session -t "$FLOAX_SESSION_NAME" 2>/dev/null; then
-        tmux new-session -d -s "$FLOAX_SESSION_NAME"
-        tmux set-option -t "$FLOAX_SESSION_NAME" status off
+    if ! tmux has-session -t "$effective_session" 2>/dev/null; then
+        tmux new-session -d -s "$effective_session"
+        tmux set-option -t "$effective_session" status off
     fi
-    tmux movew -t "$FLOAX_SESSION_NAME"
-    tmux_popup
+    tmux movew -t "$effective_session"
+    tmux_popup "$effective_session"
 }
 
 action=$1

--- a/scripts/floax.sh
+++ b/scripts/floax.sh
@@ -3,12 +3,10 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/utils.sh"
 
-tmux setenv -g ORIGIN_SESSION "$(tmux display -p '#{session_name}')"
-if [ -z "$FLOAX_SESSION_NAME" ]; then
-    FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
-fi
+current_session="$(tmux display -p '#{session_name}')"
 
-if [ "$(tmux display-message -p '#{session_name}')" = "$FLOAX_SESSION_NAME" ]; then
+if is_floax_session "$current_session"; then
+    # We're inside a floax popup — detach to close it
     unset_bindings
 
     if [ -z "$FLOAX_TITLE" ]; then
@@ -18,15 +16,17 @@ if [ "$(tmux display-message -p '#{session_name}')" = "$FLOAX_SESSION_NAME" ]; t
     tmux setenv -g FLOAX_TITLE "$FLOAX_TITLE"
     tmux detach-client
 else
+    # We're in a regular session — open a per-session popup
+    tmux setenv -g ORIGIN_SESSION "$current_session"
+    effective_session="$(floax_effective_session "$current_session")"
+
     set_bindings
 
-    # Check if the session 'scratch' exists
-    if tmux has-session -t "$FLOAX_SESSION_NAME" 2>/dev/null; then
-        tmux_popup
+    if tmux has-session -t "$effective_session" 2>/dev/null; then
+        tmux_popup "$effective_session"
     else
-        # Create a new session named 'scratch' and attach to it
-        tmux new-session -d -c "$(tmux display-message -p '#{pane_current_path}')" -s "$FLOAX_SESSION_NAME"
-        tmux set-option -t "$FLOAX_SESSION_NAME" status off
-        tmux_popup
+        tmux new-session -d -c "$(tmux display-message -p '#{pane_current_path}')" -s "$effective_session"
+        tmux set-option -t "$effective_session" status off
+        tmux_popup "$effective_session"
     fi
 fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -3,13 +3,10 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/utils.sh"
 
-# Function to check if the current session name matches "scratch"
+# Function to check if the current session is a floax session
 check_current_session() {
-    if [ -z "$FLOAX_SESSION_NAME" ]; then
-        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
-    fi
     current_session=$(tmux display-message -p '#{session_name}')
-    if [ "$current_session" != "$FLOAX_SESSION_NAME" ]; then
+    if ! is_floax_session "$current_session"; then
         tmux menu \
             "pop current window" p "run \"$CURRENT_DIR/embed.sh pop\"" 
         exit 0
@@ -17,7 +14,6 @@ check_current_session() {
 }
 
 check_current_session
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tmux menu \
     "size down" - "run \"$CURRENT_DIR/zoom-options.sh in\"" \
     "size up" + "run \"$CURRENT_DIR/zoom-options.sh out\"" \

--- a/scripts/move.sh
+++ b/scripts/move.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_DIR/utils.sh"
+
 direction=$1
 x=$(tmux display-message -p '#{popup_centre_x}')
 y=$(tmux display-message -p '#{popup_centre_y}')
@@ -24,6 +27,9 @@ esac;
 
 # pane_bottom=$(tmux display-message -p '#{pane_bottom}')
 # pane_right=$(tmux display-message -p '#{pane_right}')
+ORIGIN_SESSION="$(envvar_value ORIGIN_SESSION)"
+effective_session="$(floax_effective_session "$ORIGIN_SESSION")"
+
 tmux detach-client
-tmux popup -E "$motion" "tmux attach-session -t \"$FLOAX_SESSION_NAME\""
+tmux popup -E "$motion" "tmux attach-session -t \"$effective_session\""
 # tmux display-message "$pane_top $pane_left $motion"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -23,10 +23,36 @@ FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
 DEFAULT_TITLE='FloaX: C-M-s 󰘕   C-M-b 󰁌   C-M-f 󰊓   C-M-r 󰑓   C-M-e 󱂬   C-M-d '
 FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
 DEFAULT_SESSION_NAME='scratch'
+FLOAX_PER_SESSION=$(envvar_value FLOAX_PER_SESSION)
+
+# Returns the effective floax session name.
+# When per-session is enabled: <base>_<origin>
+# When per-session is disabled: <base> (global)
+floax_effective_session() {
+    local origin="$1"
+    local base="${FLOAX_SESSION_NAME:-$DEFAULT_SESSION_NAME}"
+    if [ "$FLOAX_PER_SESSION" = "true" ]; then
+        echo "${base}_${origin}"
+    else
+        echo "$base"
+    fi
+}
+
+# Checks if a session name is a floax session
+is_floax_session() {
+    local session="$1"
+    local base="${FLOAX_SESSION_NAME:-$DEFAULT_SESSION_NAME}"
+    if [ "$FLOAX_PER_SESSION" = "true" ]; then
+        [[ "$session" == "${base}_"* ]]
+    else
+        [[ "$session" == "$base" ]]
+    fi
+}
+
 
 set_bindings() {
     tmux bind -n C-M-s run "$CURRENT_DIR/zoom-options.sh in"
-    tmux bind -n c-M-b run "$CURRENT_DIR/zoom-options.sh out"
+    tmux bind -n C-M-b run "$CURRENT_DIR/zoom-options.sh out"
     tmux bind -n C-M-f run "$CURRENT_DIR/zoom-options.sh full"
     tmux bind -n C-M-r run "$CURRENT_DIR/zoom-options.sh reset"
     tmux bind -n C-M-e run "$CURRENT_DIR/embed.sh embed"
@@ -66,21 +92,19 @@ is_tmux_version_supported() {
 }
 
 tmux_popup() {
-    if [ -z "$FLOAX_SESSION_NAME" ]; then
-        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
-    fi
+    local target_session="${1:-${FLOAX_SESSION_NAME:-$DEFAULT_SESSION_NAME}}"
     # TODO: make this optional:
     current_dir=$(tmux display -p '#{pane_current_path}')
-    scratch_path=$(tmux display -t "$FLOAX_SESSION_NAME" -p '#{pane_current_path}')
+    scratch_path=$(tmux display -t "$target_session" -p '#{pane_current_path}')
     if [ "$scratch_path" != "$current_dir" ] && [ "$FLOAX_CHANGE_PATH" = "true" ]; then
-        tmux send-keys -R -t "$FLOAX_SESSION_NAME" " cd \"$current_dir\"" C-m
+        tmux send-keys -R -t "$target_session" " cd \"$current_dir\"" C-m
     fi
 
     if is_tmux_version_supported; then
-        if ! pop; then
-            tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 
+        if ! pop "$target_session"; then
+            tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')"
             tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')"
-            pop
+            pop "$target_session"
         fi
     else
         tmux display-message \
@@ -90,6 +114,8 @@ tmux_popup() {
 }
 
 pop() {
+    local target_session="${1:-${FLOAX_SESSION_NAME:-$DEFAULT_SESSION_NAME}}"
+
     FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
     FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
 
@@ -98,12 +124,7 @@ pop() {
         FLOAX_TITLE="$DEFAULT_TITLE"
     fi
 
-    FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
-    if [ -z "$FLOAX_SESSION_NAME" ]; then
-        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
-    fi
-
-    tmux set-option -t "$FLOAX_SESSION_NAME" detach-on-destroy on
+    tmux set-option -t "$target_session" detach-on-destroy on
     tmux popup \
         -S fg="$FLOAX_BORDER_COLOR" \
         -s fg="$FLOAX_TEXT_COLOR" \
@@ -112,5 +133,5 @@ pop() {
         -h "$FLOAX_HEIGHT" \
         -b rounded \
         -E \
-        "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
+        "tmux attach-session -t \"$target_session\""
 }

--- a/scripts/zoom-options.sh
+++ b/scripts/zoom-options.sh
@@ -3,35 +3,37 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/utils.sh"
 
+ORIGIN_SESSION="$(envvar_value ORIGIN_SESSION)"
+effective_session="$(floax_effective_session "$ORIGIN_SESSION")"
+
 resize() {
     current_width=$(tmux display -p '#{window_width}')
     current_height=$(tmux display -p '#{window_height}')
     if [ $((current_height+step)) -le 0 ] || [ $((current_width+step)) -le 0 ]; then
         return
     fi
-    ORIGIN_SESSION="$(envvar_value ORIGIN_SESSION)"
-    if [ $((current_height+step)) -gt "$(tmux display -p -t "$ORIGIN_SESSION" '#{window_height}')" ] || 
+    if [ $((current_height+step)) -gt "$(tmux display -p -t "$ORIGIN_SESSION" '#{window_height}')" ] ||
         [ $((current_width+step)) -gt "$(tmux display -p -t "$ORIGIN_SESSION" '#{window_width}')" ]; then
         return
     fi
     tmux setenv -g FLOAX_WIDTH $((current_width+step))
     tmux setenv -g FLOAX_HEIGHT $((current_height+step))
     tmux detach-client
-    tmux_popup
+    tmux_popup "$effective_session"
 }
 
 full_screen() {
     tmux setenv -g FLOAX_WIDTH 100%
     tmux setenv -g FLOAX_HEIGHT 100%
     tmux detach-client
-    tmux_popup
+    tmux_popup "$effective_session"
 }
 
 reset_size() {
     tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 
     tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')" 
     tmux detach-client
-    tmux_popup
+    tmux_popup "$effective_session"
 }
 
 unlock_bindings() {
@@ -48,7 +50,7 @@ lock_bindings() {
 change_popup_title() {
     tmux setenv -g FLOAX_TITLE "$1"
     tmux detach-client
-    tmux_popup
+    tmux_popup "$effective_session"
 }
 
 case "$1" in


### PR DESCRIPTION
Add opt-in support for per-session popup windows via a new @floax-per-session option.

By default, FloaX uses a single global popup session (e.g. scratch). When @floax-per-session is set to 'true', each tmux session gets its own isolated popup session named <base>_<session> (e.g. scratch_myproject, scratch_dev).

This is useful when working with multiple tmux sessions simultaneously — each session maintains its own popup state, history, and working directory independently.

Usage:

  set -g @floax-per-session 'true'

When disabled (default), behavior is identical to the current version — fully backward compatible.

Changes:

- floax.tmux — read new @floax-per-session option (default 'false')
- scripts/utils.sh — add helper functions (floax_effective_session, is_floax_session) that resolve the correct session name based on the option. tmux_popup() and pop() now accept a target_session argument
- scripts/floax.sh — use is_floax_session() for popup detection and floax_effective_session() for session creation
- scripts/zoom-options.sh — pass effective session to tmux_popup for resize/fullscreen/reset/lock
- scripts/embed.sh — use effective session for embed/pop operations
- scripts/menu.sh — use is_floax_session() instead of exact name match
- scripts/move.sh — add missing utils.sh source, use effective session

Backward compatibility:

No breaking changes. Default behavior (@floax-per-session 'false') is identical to the current version.

Usage example:

https://github.com/user-attachments/assets/6547e1c4-6faf-45ff-a875-e460aae967dd

