### PR TITLE
fix: capitalize C-M-b keybind in set_bindings

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -26,7 +26,7 @@ DEFAULT_SESSION_NAME='scratch'
 
 set_bindings() {
     tmux bind -n C-M-s run "$CURRENT_DIR/zoom-options.sh in"
-    tmux bind -n c-M-b run "$CURRENT_DIR/zoom-options.sh out"
+    tmux bind -n C-M-b run "$CURRENT_DIR/zoom-options.sh out"
     tmux bind -n C-M-f run "$CURRENT_DIR/zoom-options.sh full"
     tmux bind -n C-M-r run "$CURRENT_DIR/zoom-options.sh reset"
     tmux bind -n C-M-e run "$CURRENT_DIR/embed.sh embed"


### PR DESCRIPTION
## Problem

The zoom-out keybind `C-M-b` in `set_bindings()` is written as lowercase `c-M-b` (line 29 of `scripts/utils.sh`). tmux key names are case-sensitive, so this binding is never matched when the user presses Ctrl+Meta+b.

All other bindings in the same function use uppercase `C-M-*`.

## Fix

`c-M-b` → `C-M-b`

## Testing

Opened floax popup, pressed `C-M-b` — zoom-out now works as expected.