### PR TITLE
Fix popup reattach after detach and resize accuracy

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -26,7 +26,7 @@ DEFAULT_SESSION_NAME='scratch'
 
 set_bindings() {
     tmux bind -n C-M-s run "$CURRENT_DIR/zoom-options.sh in"
-    tmux bind -n c-M-b run "$CURRENT_DIR/zoom-options.sh out"
+    tmux bind -n C-M-b run "$CURRENT_DIR/zoom-options.sh out"
     tmux bind -n C-M-f run "$CURRENT_DIR/zoom-options.sh full"
     tmux bind -n C-M-r run "$CURRENT_DIR/zoom-options.sh reset"
     tmux bind -n C-M-e run "$CURRENT_DIR/embed.sh embed"
@@ -89,6 +89,34 @@ tmux_popup() {
     fi
 }
 
+pop_with_client() {
+    local target_client="$1"
+    FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
+    FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
+
+    FLOAX_TITLE=$(envvar_value FLOAX_TITLE)
+    if [ -z "$FLOAX_TITLE" ]; then
+        FLOAX_TITLE="$DEFAULT_TITLE"
+    fi
+
+    FLOAX_SESSION_NAME=$(envvar_value FLOAX_SESSION_NAME)
+    if [ -z "$FLOAX_SESSION_NAME" ]; then
+        FLOAX_SESSION_NAME="$DEFAULT_SESSION_NAME"
+    fi
+
+    tmux set-option -t "$FLOAX_SESSION_NAME" detach-on-destroy on
+    tmux popup \
+        -c "$target_client" \
+        -S fg="$FLOAX_BORDER_COLOR" \
+        -s fg="$FLOAX_TEXT_COLOR" \
+        -T "$FLOAX_TITLE" \
+        -w "$FLOAX_WIDTH" \
+        -h "$FLOAX_HEIGHT" \
+        -b rounded \
+        -E \
+        "tmux attach-session -t \"$FLOAX_SESSION_NAME\""
+}
+
 pop() {
     FLOAX_WIDTH=$(envvar_value FLOAX_WIDTH)
     FLOAX_HEIGHT=$(envvar_value FLOAX_HEIGHT)
@@ -112,5 +140,5 @@ pop() {
         -h "$FLOAX_HEIGHT" \
         -b rounded \
         -E \
-        "tmux attach-session -t \"$FLOAX_SESSION_NAME\"" 
+        "tmux attach-session -t \"$FLOAX_SESSION_NAME\""
 }

--- a/scripts/zoom-options.sh
+++ b/scripts/zoom-options.sh
@@ -3,40 +3,71 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/utils.sh"
 
+# Get the outer client's tty so we can target it after detaching the inner client.
+# Must be called BEFORE tmux detach-client.
+get_outer_client() {
+    local origin_session
+    origin_session="$(envvar_value ORIGIN_SESSION)"
+    tmux list-clients -t "${origin_session:-0}" -F '#{client_tty}' 2>/dev/null | head -1
+}
+
 resize() {
+    # '#{window_width}' returns the inner pane size (excluding popup border).
+    # But tmux popup -w/-h includes the border (2 lines/chars for -b rounded).
+    # So we add 2 to convert from inner size to popup size.
     current_width=$(tmux display -p '#{window_width}')
     current_height=$(tmux display -p '#{window_height}')
+    current_width=$((current_width + 2))
+    current_height=$((current_height + 2))
     if [ $((current_height+step)) -le 0 ] || [ $((current_width+step)) -le 0 ]; then
         return
     fi
     ORIGIN_SESSION="$(envvar_value ORIGIN_SESSION)"
-    if [ $((current_height+step)) -gt "$(tmux display -p -t "$ORIGIN_SESSION" '#{window_height}')" ] || 
-        [ $((current_width+step)) -gt "$(tmux display -p -t "$ORIGIN_SESSION" '#{window_width}')" ]; then
+    if [ $((current_height+step)) -gt "$(tmux display -p -t "${ORIGIN_SESSION}:" '#{window_height}')" ] || 
+        [ $((current_width+step)) -gt "$(tmux display -p -t "${ORIGIN_SESSION}:" '#{window_width}')" ]; then
         return
     fi
     tmux setenv -g FLOAX_WIDTH $((current_width+step))
     tmux setenv -g FLOAX_HEIGHT $((current_height+step))
+    local outer_client
+    outer_client="$(get_outer_client)"
     tmux detach-client
-    tmux_popup
+    if [ -n "$outer_client" ]; then
+        pop_with_client "$outer_client"
+    else
+        tmux_popup
+    fi
 }
 
 full_screen() {
     tmux setenv -g FLOAX_WIDTH 100%
     tmux setenv -g FLOAX_HEIGHT 100%
+    local outer_client
+    outer_client="$(get_outer_client)"
     tmux detach-client
-    tmux_popup
+    if [ -n "$outer_client" ]; then
+        pop_with_client "$outer_client"
+    else
+        tmux_popup
+    fi
 }
 
 reset_size() {
     tmux setenv -g FLOAX_WIDTH "$(tmux_option_or_fallback '@floax-width' '80%')" 
     tmux setenv -g FLOAX_HEIGHT "$(tmux_option_or_fallback '@floax-height' '80%')" 
+    local outer_client
+    outer_client="$(get_outer_client)"
     tmux detach-client
-    tmux_popup
+    if [ -n "$outer_client" ]; then
+        pop_with_client "$outer_client"
+    else
+        tmux_popup
+    fi
 }
 
 unlock_bindings() {
     set_bindings
-    change_popup_title "$FLOAX_TITLE"
+    change_popup_title "$DEFAULT_TITLE"
 }
 
 lock_bindings() {
@@ -47,8 +78,14 @@ lock_bindings() {
 
 change_popup_title() {
     tmux setenv -g FLOAX_TITLE "$1"
+    local outer_client
+    outer_client="$(get_outer_client)"
     tmux detach-client
-    tmux_popup
+    if [ -n "$outer_client" ]; then
+        pop_with_client "$outer_client"
+    else
+        tmux_popup
+    fi
 }
 
 case "$1" in


### PR DESCRIPTION
## Summary

This PR fixes several bugs that caused popup operations (resize, fullscreen, reset, title change) to silently fail after detaching from the popup.

### Root Cause

After `tmux detach-client` inside the popup, the popup's virtual client disappears. A subsequent `tmux_popup` call has no client to target, so the popup silently fails to reappear.

### Changes

- **Fix binding typo**: `c-M-b` → `C-M-b` (lowercase `c-` is not a valid tmux modifier prefix)
- **Add `pop_with_client()`**: Opens the popup targeting a specific client tty via `-c`, solving the reattach failure
- **Add `get_outer_client()`**: Captures the outer terminal's tty *before* `detach-client`, so it can be used to re-open the popup on the correct terminal
- **Fix resize accuracy**: Add +2 border compensation — `#{window_width}`/`#{window_height}` return the inner pane size (excluding border), but `tmux popup -w/-h` expect sizes *including* the border (2 lines/chars for `-b rounded`)
- **Fix session targeting**: Append `:` to `ORIGIN_SESSION` in `tmux display -p -t` for unambiguous session:target format
- **Fix `unlock_bindings`**: Reset title to `$DEFAULT_TITLE` instead of unset `$FLOAX_TITLE` shell variable
- **Graceful fallback**: When `get_outer_client` fails (no outer client found), fall back to original `tmux_popup` behavior
- **Remove trailing whitespace**